### PR TITLE
Fix code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/src/todos/todos.service.ts
+++ b/src/todos/todos.service.ts
@@ -25,7 +25,7 @@ export class TodosService {
   }
 
   async findOne(id: string, userId: Types.ObjectId): Promise<Todo> {
-    const todo = await this.todoModal.findOne({ _id: id, userId }).exec();
+    const todo = await this.todoModal.findOne({ _id: { $eq: id }, userId }).exec();
 
     if (!todo) {
       throw new NotFoundException('Todo not found');
@@ -41,7 +41,7 @@ export class TodosService {
   ): Promise<Todo> {
     await this.findOne(id, userId);
 
-    await this.todoModal.updateOne({ _id: id }, todo).exec();
+    await this.todoModal.updateOne({ _id: { $eq: id } }, todo).exec();
 
     return this.findOne(id, userId);
   }
@@ -49,7 +49,7 @@ export class TodosService {
   async remove(id: string, userId: Types.ObjectId): Promise<Todo> {
     const todo = await this.findOne(id, userId);
 
-    await this.todoModal.deleteOne({ _id: id }).exec();
+    await this.todoModal.deleteOne({ _id: { $eq: id } }).exec();
 
     return todo;
   }


### PR DESCRIPTION
Fixes [https://github.com/hossam7amdy/todo-server/security/code-scanning/1](https://github.com/hossam7amdy/todo-server/security/code-scanning/1)

To fix the problem, we need to ensure that the `id` parameter is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator, which ensures that the user input is interpreted as a literal value and not as a query object. This approach will prevent NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
